### PR TITLE
Add expandable summary row

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,6 +6,12 @@
     <title>GW2 API STATUS</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-beta/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css">
+    <style>
+      .result-row--summary:hover {
+        cursor: pointer;
+        background: #f7f7f7;
+      }
+    </style>
   </head>
   <body>
     <noscript>

--- a/frontend/src/ResultsRow.js
+++ b/frontend/src/ResultsRow.js
@@ -2,10 +2,10 @@ import { h, Component } from 'preact'
 
 class ResultsRow extends Component {
   render () {
-    const data = this.props.data
+    const {data, className, onClick} = this.props
 
     return (
-      <tr>
+      <tr onClick={onClick} className={className}>
         <td width={400}>{data.name}</td>
         <td>
           {data.status < 400 && (
@@ -55,12 +55,16 @@ class ResultsRow extends Component {
               <span className='text-danger oi oi-timer'/>
             )}
 
-            <div className='ml-2'>{data.duration.toLocaleString()} ms</div>
+            <div className='ml-2'>{data.duration !== 0 ? `${data.duration.toLocaleString()} ms` : ''}</div>
           </div>
         </td>
       </tr>
     )
   }
+}
+
+ResultsRow.defaultProps = {
+  className: 'result-row'
 }
 
 export default ResultsRow

--- a/frontend/src/ResultsTable.js
+++ b/frontend/src/ResultsTable.js
@@ -2,9 +2,18 @@ import {h, Component} from 'preact'
 import ResultsRow from './ResultsRow'
 
 class ResultsTable extends Component {
+  constructor (props, context) {
+    super(props, context)
+
+    this.state = {
+      expanded: false
+    }
+  }
+
   render () {
     const results = this.props.results
     const workingCount = results.data.filter(x => x.severity === 0).length
+    const {expanded} = this.state
 
     return (
       <div>
@@ -23,15 +32,35 @@ class ResultsTable extends Component {
             </thead>
             <tbody>
               {results.data.filter(x => x.severity > 0).map(x => <ResultsRow data={x} />)}
+              {expanded
+                ? results.data.filter(x => x.severity === 0).map(x => <ResultsRow data={x} />)
+                : this.renderSummaryRow(results, workingCount)}
             </tbody>
           </table>
-
-          <h4 className='text-center mt-4'>
-            {workingCount === results.data.length ? 'All' : workingCount} endpoints fully
-            operational 🎉
-          </h4>
         </div>
       </div>
+    )
+  }
+
+  renderSummaryRow (results, workingCount) {
+    if (workingCount === 0) {
+      return null
+    }
+
+    const text = '▶ ' +
+      (workingCount === results.data.length ? 'All' : workingCount) + 
+      ' endpoints fully operational 🎉'
+
+    const data = {
+      name: text,
+      status: 200,
+      schemaValid: true,
+      snapshotValid: true,
+      duration: 0
+    }
+
+    return (
+      <ResultsRow data={data} onClick={() => this.setState({expanded: true})} className={'result-row--summary'} />
     )
   }
 }


### PR DESCRIPTION
This adds a summary row that can be expanded by clicking on it to show the status of all passing endpoints.

<img width="940" alt="summary row" src="https://user-images.githubusercontent.com/2511547/31044348-f7c60b66-a5cd-11e7-9f5c-e68f67cc3d0d.png">
