### PR TITLE
Add error reason tooltip

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,6 +6,36 @@
     <title>GW2 API STATUS</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-beta/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css">
+    <style>
+      .has-tooltip { position: relative; }
+      .has-tooltip:hover .status-tooltip { opacity: 1; }
+      .status-tooltip {
+        opacity: 0;
+        transition: opacity ease .3s;
+        pointer-events: none;
+        position: absolute;
+        left: 50%;
+        top: -5px;
+        transform: translate(-50%, -100%);
+        background: black;
+        border-radius: 3px;
+        white-space: nowrap;
+        color: #fff;
+        padding: 2px 8px;
+        font-size: 12px;
+      }
+      .status-tooltip:after {
+        content: '';
+        display: block;
+        border: solid;
+        border-width: 6px 6px 0 6px;
+        border-color: black transparent;
+        position: absolute;
+        left: 50%;
+        margin-left: -6px;
+        bottom: -6px;
+      }
+    </style>
   </head>
   <body>
     <noscript>

--- a/frontend/src/ResultsRow.js
+++ b/frontend/src/ResultsRow.js
@@ -13,9 +13,10 @@ class ResultsRow extends Component {
           )}
 
           {data.status >= 400 && (
-            <div className='d-flex align-items-center'>
+            <div className='d-flex align-items-center has-tooltip'>
               <span className='text-danger oi oi-circle-x'/>
               <div className='ml-2'>{data.status}</div>
+              <div className='status-tooltip'>{data.error || 'Unknown error'}</div>
             </div>
           )}
         </td>

--- a/worker/src/testEndpoint.js
+++ b/worker/src/testEndpoint.js
@@ -5,10 +5,13 @@ const matchSnapshot = require('./matchSnapshot')
 async function testEndpoint (endpoint) {
   const {duration, response} = await requestApi(endpoint.url)
 
+  const error = response.status >= 400 && response.content && response.content.text
+
   let result = {
     name: endpoint.name,
     status: response.status,
-    duration: duration
+    duration,
+    error
   }
 
   if (result.status !== 200) {


### PR DESCRIPTION
This adds a tooltip for erroring endpoints showing `response.content.text` (if set).

I didn't use the default bootstrap tooltips because they require javascript and instead wrote my own CSS only ones.

<img width="630" alt="tooltip" src="https://user-images.githubusercontent.com/2511547/31044287-c5a38a60-a5cc-11e7-9b76-6af6fa2a4c1e.png">
