### PR TITLE
Require /v2/build schema to return the current build

### DIFF
--- a/worker/__schemas__/v2_build.json
+++ b/worker/__schemas__/v2_build.json
@@ -4,8 +4,10 @@
   "properties": {
     "id": {
       "type": "number",
-      "required": true
+      "minimum": 115267,
+      "exclusiveMinimum": true
     }
   },
+  "required": ["id"],
   "additionalProperties": false
 }


### PR DESCRIPTION
`/v2/build` has been broken for some time and always returns build 115267. This updates the schema to require a value greater than that.

This will make sure people know that this endpoint is currently broken, and might help us notice when the build is correct again.

Not sure if you want to merge this…