### PR TITLE
Update `/v2/account` schema

### DIFF
--- a/worker/__schemas__/v2_account.json
+++ b/worker/__schemas__/v2_account.json
@@ -53,6 +53,21 @@
       "type": "boolean",
       "required": true
     },
+    "wvw": {
+      "type": "object",
+      "properties": {
+        "team_id": {
+          "type": "number",
+          "required": true
+        },
+        "rank": {
+          "type": "number",
+          "required": true
+        }
+      },
+      "additionalProperties": false,
+      "required": true
+    },
     "fractal_level": {
       "type": "number",
       "required": true
@@ -62,10 +77,6 @@
       "required": true
     },
     "monthly_ap": {
-      "type": "number",
-      "required": true
-    },
-    "wvw_rank": {
       "type": "number",
       "required": true
     },


### PR DESCRIPTION
Updated the `/v2/account` schema to the latest version.

Maybe the schema version should be pinned instead of using `latest` for all requests?